### PR TITLE
Fleming 0.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,17 +64,16 @@ An aware datetime object that was the result of converting dt into tz. If return
     print dt
     2013-02-04 00:00:00
 
-### add_timedelta(dt, td, within_tz=None, return_naive=False)<a name="add_timedelta"></a>
+### add_timedelta(dt, td, within_tz=None)<a name="add_timedelta"></a>
 Given a naive or aware datetime dt, add a timedelta td to it and return it. If within_tz is specified, the datetime arithmetic happens with regard to the timezone. Proper measures are used to ensure that datetime arithmetic across a DST border is handled properly.
 
 **Args:**
 - dt: A naive or aware datetime object. If it is naive, it is assumed to be UTC.
 - td: A timedelta (or relativedelta) object to add to dt.
 - within_tz: A pytz timezone object. If provided, dt will be converted to this timezone before datetime arithmetic and then converted back to its original timezone afterwards.
-- return_naive: A boolean defaulting to False. If True, the result is returned as a naive datetime object with tzinfo equal to None.
 
 **Returns:**
-An aware datetime object that results from adding td to dt. The timezone of the returned datetime will be equivalent to the original timezone of dt (or its DST equivalent if a DST border was crossed). If return_naive is True, the returned value has no tzinfo object.
+A datetime object that results from adding td to dt. The timezone of the returned datetime will be equivalent to the original timezone of dt (or its DST equivalent if a DST border was crossed). If the original time was naive, the returned value is naive.
 
 **Examples:**
 
@@ -82,12 +81,12 @@ An aware datetime object that results from adding td to dt. The timezone of the 
     import datetime
     import fleming
 
-    # Do a basic timedelta addition to a naive UTC time and create an aware UTC time
+    # Do a basic timedelta addition to a naive UTC time and create a naive UTC time
     # two weeks in the future
     dt = datetime.datetime(2013, 3, 1)
     dt = fleming.add_timedelta(dt, datetime.timedelta(weeks=2))
     print dt
-    2013-03-15 00:00:00+00:00
+    2013-03-15 00:00:00
 
     # Do addition on an EST datetime where the arithmetic does not cross over DST
     dt = fleming.convert_to_tz(dt, pytz.timezone('US/Eastern'))
@@ -104,9 +103,9 @@ An aware datetime object that results from adding td to dt. The timezone of the 
     print dt
     2013-03-01 20:00:00-05:00
 
-    # Take a UTC time and do datetime arithmetic in regards to EST. Do the arithmetic
+    # Take an aware UTC time and do datetime arithmetic in regards to EST. Do the arithmetic
     # such that a DST border is crossed
-    dt = datetime.datetime(2013, 3, 1, 5)
+    dt = datetime.datetime(2013, 3, 1, 5, tzinfo=pytz.utc)
     # It should be midnight in EST
     print fleming.convert_to_tz(dt, pytz.timezone('US/Eastern'))
     2013-03-01 00:00:00-05:00
@@ -123,7 +122,7 @@ An aware datetime object that results from adding td to dt. The timezone of the 
     2013-03-15 00:00:00-04:00
 
 
-### floor(dt, within_tz=None, return_naive=False, year=None, month=None, week=None, day=None, hour=None, minute=None, second=None, microsecond=None)<a name="floor"></a>
+### floor(dt, within_tz=None, year=None, month=None, week=None, day=None, hour=None, minute=None, second=None, microsecond=None)<a name="floor"></a>
 Perform a floor on a datetime, rounding the datetime to its nearest provided interval. Available intervals are year, month, week, day, hour, minute, second, and microsecond.
 
 For example, to round to the nearest month, provide month=1 as input. Give a value like 3 to the month argument and it will round to the nearest trimonth in a year (i.e. the nearest quarter). Values for other intervals operate in the same way, such as rounding down to the nearest day in a month (or nearest triday).
@@ -137,7 +136,6 @@ Note that multiple combinations of attributes can be used where they make sense,
 **Args:**
 - dt: A naive or aware datetime object. If it is naive, it is assumed to be UTC
 - within_tz: A pytz timezone object. If given, the floor will be performed with respect to the timezone.
-- return_naive: A boolean specifying whether to return the datetime object as naive.
 - year: Specifies the yearly interval to round down to. Defaults to None.
 - month: Specifies the monthly interval (inside of a year) to round down to. Defaults to None.
 - week: Specifies to round to the beginning of the previous week. Defaults to None and only accepts a possible value of 1.
@@ -146,10 +144,9 @@ Note that multiple combinations of attributes can be used where they make sense,
 - minute: Specifies the minute interval to round down to (inside of an hour). Defaults to None.
 - second: Specifies the second interval to round down to (inside of a minute). Defaults to None.
 - microsecond: Specfies the microsecond interval to round down to (inside of a second). Defaults to None.
-- extra_td_if_no_floor: An extra timedelta to add to the floored result if the resulting floor is different than the input. Only used by the ceil function and not intended for use by users.
 
 **Returns:**
-An aware datetime object that results from flooring dt to the previous interval. The timezone of the returned datetime will be equivalent to the original timezone of dt (or its DST equivalent if a DST border was crossed). If return_naive is True, the returned value has no tzinfo object.
+A datetime object that results from flooring dt to the interval. The timezone of the returned datetime will be equivalent to the original timezone of dt (or its DST equivalent if a DST border was crossed). If the input time was naive, it returns a naive datetime object.
 
 **Raises:**
 ValueError if the interval is an invalid value.
@@ -160,24 +157,23 @@ ValueError if the interval is an invalid value.
     import pytz
     import fleming
 
-    # Do basic floors in naive UTC time. Results are UTC aware
+    # Do basic floors in naive UTC time. Results are naive UTC.
     print fleming.floor(datetime.datetime(2013, 3, 3, 5), year=1)
-    2013-01-01 00:00:00+00:00
-
+    2013-01-01 00:00:00
     print fleming.floor(datetime.datetime(2013, 3, 3, 5), month=1)
-    2013-03-01 00:00:00+00:00
+    2013-03-01 00:00:00
 
     # Weeks start on Monday, so the floor will be for the previous Monday
     print fleming.floor(datetime.datetime(2013, 3, 3, 5), week=1)
-    2013-02-25 00:00:00+00:00
+    2013-02-25 00:00:00
 
     print fleming.floor(datetime.datetime(2013, 3, 3, 5), day=1)
-    2013-03-03 00:00:00+00:00
-
-    # Use return_naive if you don't want to return aware datetimes
-    print fleming.floor(
-        datetime.datetime(2013, 3, 3, 5), day=1, return_naive=True)
     2013-03-03 00:00:00
+
+    # Pass an aware datetime and return an aware datetime
+    print fleming.floor(
+        datetime.datetime(2013, 3, 3, 5, tzinfo=pytz.utc), day=1)
+    2013-03-03 00:00:00+00:00
 
     # Peform a floor in EST. The result is in EST
     dt = fleming.convert_to_tz(
@@ -206,9 +202,9 @@ ValueError if the interval is an invalid value.
     dt = datetime.datetime(2013, 2, 1)
     # Since it is January 31 in EST, the resulting floored value
     # for a day will be the previous day. Also, the returned value is
-    # in the original timezone of UTC
+    # in the original naive timezone of UTC
     print fleming.floor(dt, day=1, within_tz=pytz.timezone('US/Eastern'))
-    2013-01-31 00:00:00+00:00
+    2013-01-31 00:00:00
 
     # Similarly, EST values can be floored relative to CST values.
     dt = fleming.convert_to_tz(
@@ -224,10 +220,10 @@ ValueError if the interval is an invalid value.
 
     # Get the starting of a quarter by using month=3
     print fleming.floor(datetime.datetime(2013, 2, 4), month=3)
-    2013-01-01 00:00:00+00:00
+    2013-01-01 00:00:00
 
 
-### ceil(dt, within_tz=None, return_naive=False, year=None, month=None, week=None, day=None, hour=None, minute=None, second=None, microsecond=None)<a name="ceil"></a>
+### ceil(dt, within_tz=None, year=None, month=None, week=None, day=None, hour=None, minute=None, second=None, microsecond=None)<a name="ceil"></a>
 Perform a ceil on a datetime to the next closest interval in the future. For example, if month=1, this function will round up the time to the next month in the future. Larger numbers can be used, such as month=3, to round up to the beginning of the next quarter.
 
 Note that this function allows combinations of interval variables (such as month=2 and day=2 to round up to the next duomonth of the year and next duoday of the month), but the smaller intervals are always not important since they will always be at the beginning of the larger interval.
@@ -235,7 +231,6 @@ Note that this function allows combinations of interval variables (such as month
 **Args:**
 - dt: A naive or aware datetime object. If it is naive, it is assumed to be UTC.
 - within_tz: A pytz timezone object. If given, the ceil will be performed with respect to the timezone.
-- return_naive: A boolean specifying whether to return the datetime object as naive.
 - year: Specifies the yearly interval to round up to. Defaults to None.
 - month: Specifies the monthly interval (inside of a year) to round up to. Defaults to None.
 - week: Specifies to round up to the beginning of the next week. Defaults to None and only accepts a possible value of 1.
@@ -246,7 +241,7 @@ Note that this function allows combinations of interval variables (such as month
 - microsecond: Specfies the microsecond interval to round up to (inside of a second). Defaults to None.
 
 **Returns:**
-An aware datetime object that results from ceiling dt to the next interval. The timezone of the returned datetime will be equivalent to the original timezone of dt (or its DST equivalent if a DST border was crossed). If return_naive is True, the returned value has no tzinfo object.
+A datetime object that results from ceiling dt to the next interval. The timezone of the returned datetime will be equivalent to the original timezone of dt (or its DST equivalent if a DST border was crossed). If the original datetime object was naive, the returned object is naive.
 
 **Raises:**
 ValueError if the interval is not a valid value.
@@ -257,24 +252,24 @@ ValueError if the interval is not a valid value.
     import pytz
     import fleming
 
-    # Do basic ceils in naive UTC time. Results are UTC aware
+    # Do basic ceils in naive UTC time. Results are naive UTC
     print fleming.ceil(datetime.datetime(2013, 3, 3, 5), year=1)
-    2014-01-01 00:00:00+00:00
+    2014-01-01 00:00:00
 
     print fleming.ceil(datetime.datetime(2013, 3, 3, 5), month=1)
-    2013-04-01 00:00:00+00:00
+    2013-04-01 00:00:00
 
     # Weeks start on Monday, so the floor will be for the next Monday
     print fleming.ceil(datetime.datetime(2013, 3, 3, 5), week=1)
-    2013-03-04 00:00:00+00:00
+    2013-03-04 00:00:00
 
     print fleming.ceil(datetime.datetime(2013, 3, 3, 5), day=1)
-    2013-03-04 00:00:00+00:00
-
-    # Use return_naive if you don't want to return aware datetimes
-    print fleming.ceil(
-        datetime.datetime(2013, 3, 3, 5), day=1, return_naive=True)
     2013-03-04 00:00:00
+
+    # Use aware datetimes to return aware datetimes
+    print fleming.ceil(
+        datetime.datetime(2013, 3, 3, 5, tzinfo=pytz.utc), day=1)
+    2013-03-04 00:00:00+00:00
 
     # Peform a ceil in CST. The result is in Pacfic time
     dt = fleming.convert_to_tz(
@@ -296,10 +291,10 @@ ValueError if the interval is not a valid value.
     # Note that doing a ceiling on a time that is already on the boundary
     # returns the original time
     print fleming.ceil(datetime.datetime(2013, 4, 1), month=1)
-    2013-04-01 00:00:00+00:00
+    2013-04-01 00:00:00
 
 
-### intervals(start_dt, td, within_tz=None, stop_dt=None, is_stop_dt_inclusive=False, count=0, return_naive=False)<a name="intervals"></a>
+### intervals(start_dt, td, within_tz=None, stop_dt=None, is_stop_dt_inclusive=False, count=0)<a name="intervals"></a>
 Returns a range of datetime objects starting from start_dt and going in increments of timedelta td. If stop_dt is specified, the intervals go to stop_dt (and include stop_dt in the return if is_stop_dt_inclusive=True). If stop_dt is None, the count variable is used to control how many iterations are in the time intervals.
 
 **Args:**
@@ -309,10 +304,9 @@ Returns a range of datetime objects starting from start_dt and going in incremen
 - stop_dt: A naive or aware datetime object that specifies the end of the intervals. Defaults to being exclusive in the intervals. If naive, it is assumed to be in UTC.
 - is_stop_dt_inclusive: True if the stop_dt should be included in the time intervals. Defaults to False.
 - count: An integer specifying a count of intervals to use if stop_dt is None.
-- return_naive: All datetimes in the intervals are returned as naive objects.
 
 **Returns:**
-A generator of datetime objects.
+A generator of datetime objects. The datetime objects are in the original timezone of the start_dt (or its DST equivalent if a border is crossed). If the input is naive, the returned intervals are naive.
 
 **Examples:**
 
@@ -323,11 +317,11 @@ A generator of datetime objects.
     # Using a naive UTC time, get intervals of time for every day.
     for dt in fleming.intervals(datetime.datetime(2013, 2, 3), datetime.timedelta(days=1), count=5):
         print dt
-    2013-02-03 00:00:00+00:00
-    2013-02-04 00:00:00+00:00
-    2013-02-05 00:00:00+00:00
-    2013-02-06 00:00:00+00:00
-    2013-02-07 00:00:00+00:00
+    2013-02-03 00:00:00
+    2013-02-04 00:00:00
+    2013-02-05 00:00:00
+    2013-02-06 00:00:00
+    2013-02-07 00:00:00
 
     # Use an EST time. Do intervals of a day. Cross the DST time border on March 10th.
     est_dt = fleming.convert_to_tz(datetime.datetime(2013, 3, 9, 5), pytz.timezone('US/Eastern'))
@@ -345,37 +339,37 @@ A generator of datetime objects.
             datetime.datetime(2013, 3, 9, 5), datetime.timedelta(days=1), within_tz=pytz.timezone('US/Eastern'),
             count=5):
         print dt
-    2013-03-09 05:00:00+00:00
-    2013-03-10 05:00:00+00:00
-    2013-03-11 04:00:00+00:00
-    2013-03-12 04:00:00+00:00
-    2013-03-13 04:00:00+00:00
+    2013-03-09 05:00:00
+    2013-03-10 05:00:00
+    2013-03-11 04:00:00
+    2013-03-12 04:00:00
+    2013-03-13 04:00:00
 
     # Use a stop time. Note that the stop time is exclusive
     for dt in fleming.intervals(
             datetime.datetime(2013, 3, 9), datetime.timedelta(weeks=1), stop_dt=datetime.datetime(2013, 3, 23)):
         print dt
-    2013-03-09 00:00:00+00:00
-    2013-03-16 00:00:00+00:00
+    2013-03-09 00:00:00
+    2013-03-16 00:00:00
 
     # Make the previous range inclusive
     for dt in fleming.intervals(
             datetime.datetime(2013, 3, 9), datetime.timedelta(weeks=1), stop_dt=datetime.datetime(2013, 3, 23),
             is_stop_dt_inclusive=True):
         print dt
-    2013-03-09 00:00:00+00:00
-    2013-03-16 00:00:00+00:00
-    2013-03-23 00:00:00+00:00
+    2013-03-09 00:00:00
+    2013-03-16 00:00:00
+    2013-03-23 00:00:00
 
     # Arbitrary timedeltas can be used for any sort of time range
     for dt in fleming.intervals(
             datetime.datetime(2013, 3, 9), datetime.timedelta(days=1, hours=2, minutes=1), count=5):
         print dt
-    2013-03-09 00:00:00+00:00
-    2013-03-10 02:01:00+00:00
-    2013-03-11 04:02:00+00:00
-    2013-03-12 06:03:00+00:00
-    2013-03-13 08:04:00+00:00
+    2013-03-09 00:00:00
+    2013-03-10 02:01:00
+    2013-03-11 04:02:00
+    2013-03-12 06:03:00
+    2013-03-13 08:04:00
 
 
 ### unix_time(dt, within_tz=None, return_ms=False)<a name="unix_time"></a>

--- a/fleming/tests/fleming_tests.py
+++ b/fleming/tests/fleming_tests.py
@@ -240,7 +240,7 @@ class TestAddTimedelta(unittest.TestCase):
     """
     Tests the add_timedelta function.
     """
-    def test_naive_within_no_tz_return_aware(self):
+    def test_naive_within_no_tz_return_naive(self):
         """
         Tests time delta arithmetic when the original time is naive and timezone
         arithmetic happens within original timezone. The returned value is
@@ -248,16 +248,6 @@ class TestAddTimedelta(unittest.TestCase):
         """
         naive_t = datetime.datetime(2013, 4, 1)
         ret = fleming.add_timedelta(naive_t, datetime.timedelta(days=2))
-        self.assertEquals(ret, datetime.datetime(2013, 4, 3, tzinfo=pytz.utc))
-
-    def test_naive_within_no_tz_return_naive(self):
-        """
-        Tests time delta arithmetic when the original time is naive and timezone
-        arithmetic happens within original timezone. The returned value is
-        also naive.
-        """
-        naive_t = datetime.datetime(2013, 4, 1)
-        ret = fleming.add_timedelta(naive_t, datetime.timedelta(days=2), return_naive=True)
         self.assertEquals(ret, datetime.datetime(2013, 4, 3))
 
     def test_aware_within_no_tz_return_aware(self):
@@ -269,17 +259,6 @@ class TestAddTimedelta(unittest.TestCase):
         ret = fleming.add_timedelta(
             aware_t, datetime.timedelta(days=1, minutes=1, seconds=1, microseconds=1))
         self.assertEquals(ret, datetime.datetime(2013, 4, 2, 0, 1, 1, 1, tzinfo=pytz.utc))
-
-    def test_aware_within_no_tz_return_naive(self):
-        """
-        Tests time delta arithmetic when the input is aware and there is no within_tz. Returned
-        values are naive.
-        """
-        aware_t = datetime.datetime(2013, 4, 1, tzinfo=pytz.utc)
-        ret = fleming.add_timedelta(
-            aware_t, datetime.timedelta(days=1, minutes=1, seconds=1, microseconds=1),
-            return_naive=True)
-        self.assertEquals(ret, datetime.datetime(2013, 4, 2, 0, 1, 1, 1))
 
     def test_aware_within_no_tz_return_aware_dst_cross(self):
         """
@@ -300,24 +279,7 @@ class TestAddTimedelta(unittest.TestCase):
         # Verify the time is midnight two weeks later
         self.assertEquals(ret, datetime.datetime(2013, 3, 15, tzinfo=ret.tzinfo))
 
-    def test_aware_within_no_tz_return_naive_dst_cross(self):
-        """
-        Tests time delta arithmetic when the input is aware and there is no within_tz. Returned
-        values are naive. Tests the case where arithmetic happens across a dst transition.
-        """
-        # Create an aware datetime that is not in DST
-        aware_t = fleming.convert_to_tz(datetime.datetime(2013, 3, 1, 5), pytz.timezone('US/Eastern'))
-        # Assert that it isn't in DST
-        self.assertEquals(aware_t.tzinfo.dst(aware_t), datetime.timedelta(0))
-        # Assert the values are midnight for EST
-        self.assertEquals(aware_t, datetime.datetime(2013, 3, 1, tzinfo=pytz.timezone('US/Eastern')))
-
-        # Add a timedelta across the DST transition (Mar 10)
-        ret = fleming.add_timedelta(aware_t, datetime.timedelta(weeks=2), return_naive=True)
-        # Verify the time is midnight two weeks later and is naive
-        self.assertEquals(ret, datetime.datetime(2013, 3, 15))
-
-    def test_naive_within_tz_return_aware_dst_cross(self):
+    def test_naive_within_tz_return_naive_dst_cross(self):
         """
         Tests time delta arithmetic when the input is naive and there is arithmetic within another timezone.
         Returned values are aware. Tests the case where arithmetic happens across a dst transition.
@@ -328,21 +290,6 @@ class TestAddTimedelta(unittest.TestCase):
         # Add a timedelta across the DST transition for EST (Mar 10)
         ret = fleming.add_timedelta(
             naive_t, datetime.timedelta(weeks=2), within_tz=pytz.timezone('US/Eastern'))
-        # Verify the time is midnight two weeks later in UTC. Note that the original hour has changed
-        # since we crossed the DST boundary in EST
-        self.assertEquals(ret, datetime.datetime(2013, 3, 15, 4, tzinfo=pytz.utc))
-
-    def test_naive_within_tz_return_naive_dst_cross(self):
-        """
-        Tests time delta arithmetic when the input is naive and there is arithmetic within another timezone.
-        Returned values are naive. Tests the case where arithmetic happens across a dst transition.
-        """
-        # Create a naive datetime assumed to be in UTC
-        naive_t = datetime.datetime(2013, 3, 1, 5)
-
-        # Add a timedelta across the DST transition for EST (Mar 10)
-        ret = fleming.add_timedelta(
-            naive_t, datetime.timedelta(weeks=2), within_tz=pytz.timezone('US/Eastern'), return_naive=True)
         # Verify the time is midnight two weeks later in UTC. Note that the original hour has changed
         # since we crossed the DST boundary in EST
         self.assertEquals(ret, datetime.datetime(2013, 3, 15, 4))
@@ -361,21 +308,6 @@ class TestAddTimedelta(unittest.TestCase):
         # Verify the time is midnight two weeks later in UTC. Note that the hour changes since it happened
         # across an EST DST boundary
         self.assertEquals(ret, datetime.datetime(2013, 3, 15, 4, tzinfo=pytz.utc))
-
-    def test_aware_within_tz_return_naive_dst_cross(self):
-        """
-        Tests time delta arithmetic when the input is aware and there is arithmetic within another timezone.
-        Returned values are naive. Tests the case where arithmetic happens across a dst transition.
-        """
-        # Create an aware datetime that is not in DST for EST
-        aware_t = fleming.convert_to_tz(datetime.datetime(2013, 3, 1, 5), pytz.utc)
-
-        # Add a timedelta across the DST transition (Mar 10) within EST
-        ret = fleming.add_timedelta(
-            aware_t, datetime.timedelta(weeks=2), within_tz=pytz.timezone('US/Eastern'), return_naive=True)
-        # Verify the time is midnight two weeks later in UTC. Note that the hour changes since it happened
-        # across an EST DST boundary
-        self.assertEquals(ret, datetime.datetime(2013, 3, 15, 4))
 
     def test_aware_est_within_cst_return_aware_dst_cross(self):
         """
@@ -399,25 +331,6 @@ class TestAddTimedelta(unittest.TestCase):
         # across a DST boundary
         self.assertEquals(ret, datetime.datetime(2013, 3, 15, tzinfo=ret.tzinfo))
 
-    def test_aware_est_within_cst_return_naive_dst_cross(self):
-        """
-        Tests time delta arithmetic when the input is aware and there is arithmetic within another timezone.
-        Returned values are naive. Tests the case where arithmetic happens across a dst transition.
-        """
-        # Create an aware datetime that is not in DST
-        aware_t = fleming.convert_to_tz(datetime.datetime(2013, 3, 1, 5), pytz.timezone('US/Eastern'))
-        # Assert that it isn't in DST
-        self.assertEquals(aware_t.tzinfo.dst(aware_t), datetime.timedelta(0))
-        # Assert the values are midnight for EST
-        self.assertEquals(aware_t, datetime.datetime(2013, 3, 1, tzinfo=pytz.timezone('US/Eastern')))
-
-        # Add a timedelta across the DST transition (Mar 10) within CST
-        ret = fleming.add_timedelta(
-            aware_t, datetime.timedelta(weeks=2), within_tz=pytz.timezone('US/Central'), return_naive=True)
-
-        # Verify the time is midnight two weeks later in EST
-        self.assertEquals(ret, datetime.datetime(2013, 3, 15))
-
 
 class TestFloor(unittest.TestCase):
     """
@@ -425,90 +338,85 @@ class TestFloor(unittest.TestCase):
     """
     def test_naive_floor_year(self):
         """
-        Tests flooring a naive datetime to a year and returning an aware datetime.
+        Tests flooring a naive datetime to a year and returning a naive datetime.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
+        t = fleming.floor(t, year=1)
+        self.assertEquals(t, datetime.datetime(2013, 1, 1))
+
+    def test_aware_floor_year(self):
+        """
+        Tests flooring an aware datetime to a year and returning an aware datetime.
+        """
+        t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40, tzinfo=pytz.utc)
         t = fleming.floor(t, year=1)
         self.assertEquals(t, datetime.datetime(2013, 1, 1, tzinfo=pytz.utc))
 
     def test_naive_floor_month(self):
         """
-        Tests flooring a naive datetime to a month and returning an aware datetime.
+        Tests flooring a naive datetime to a month and returning a naive datetime.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.floor(t, month=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 1, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 1))
 
     def test_naive_floor_week_stays_in_month(self):
         """
         Tests flooring a naive datetime to a week where the month value remains the same.
-        Returns an aware datetime.
+        Returns a naive datetime.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.floor(t, week=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 4, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 4))
 
     def test_naive_floor_week_goes_to_prev_month(self):
         """
         Tests flooring a naive datetime to a week where the month value goes backwards.
-        Return value is aware.
+        Return value is naive.
         """
         t = datetime.datetime(2013, 3, 1, 12, 23, 4, 40)
         t = fleming.floor(t, week=1)
-        self.assertEquals(t, datetime.datetime(2013, 2, 25, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 2, 25))
 
     def test_naive_floor_day(self):
         """
-        Tests flooring a naive datetime to a day. Return value is aware.
+        Tests flooring a naive datetime to a day. Return value is naive.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.floor(t, day=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 4, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 4))
 
     def test_naive_floor_day_return_naive(self):
         """
         Tests flooring a naive datetime to a day. Return value is naive.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
-        t = fleming.floor(t, day=1, return_naive=True)
+        t = fleming.floor(t, day=1)
         self.assertEquals(t, datetime.datetime(2013, 3, 4))
 
     def test_naive_floor_hour(self):
         """
-        Tests flooring a naive datetime to an hour. Return value is aware
+        Tests flooring a naive datetime to an hour. Return value is naive
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.floor(t, hour=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12))
 
     def test_naive_floor_minute(self):
         """
-        Tests flooring a naive datetime to a minute. Return value is aware.
+        Tests flooring a naive datetime to a minute. Return value is naive.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.floor(t, minute=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12, 23, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12, 23))
 
     def test_naive_floor_second(self):
         """
-        Tests flooring a naive datetime to a minute. Return value is aware
+        Tests flooring a naive datetime to a minute. Return value is naive
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.floor(t, second=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12, 23, 4, tzinfo=pytz.utc))
-
-    def test_aware_floor_year(self):
-        """
-        Tests flooring an aware datetime to a year and returning an aware datetime.
-        """
-        t = fleming.convert_to_tz(
-            datetime.datetime(2013, 3, 4, 12, 23, 4, 40), pytz.timezone('US/Eastern'))
-        # Original time zone should not be in DST
-        self.assertEquals(t.tzinfo.dst(t), datetime.timedelta(0))
-        ret = fleming.floor(t, year=1)
-        # Resulting time zone should not be in DST
-        self.assertEquals(ret.tzinfo.dst(ret), datetime.timedelta(0))
-        self.assertEquals(ret, datetime.datetime(2013, 1, 1, tzinfo=t.tzinfo))
+        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12, 23, 4))
 
     def test_aware_floor_month(self):
         """
@@ -563,17 +471,6 @@ class TestFloor(unittest.TestCase):
         # Resulting time zone should not be in DST
         self.assertEquals(ret.tzinfo.dst(ret), datetime.timedelta(0))
         self.assertEquals(ret, datetime.datetime(2013, 3, 4, tzinfo=t.tzinfo))
-
-    def test_aware_floor_day_return_naive(self):
-        """
-        Tests flooring an aware datetime to a day. Return value is naive.
-        """
-        t = fleming.convert_to_tz(
-            datetime.datetime(2013, 3, 4, 12, 23, 4, 40), pytz.timezone('US/Eastern'))
-        # Original time zone should not be in DST
-        self.assertEquals(t.tzinfo.dst(t), datetime.timedelta(0))
-        ret = fleming.floor(t, day=1, return_naive=True)
-        self.assertEquals(ret, datetime.datetime(2013, 3, 4))
 
     def test_aware_floor_hour(self):
         """
@@ -665,7 +562,7 @@ class TestFloor(unittest.TestCase):
         ret = fleming.floor(t, day=1, within_tz=pytz.timezone('US/Eastern'))
         # The return value should be for the last day of the previous month, and the
         # timezone should still be in UTC
-        self.assertEquals(ret, datetime.datetime(2013, 3, 31, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 3, 31))
 
     def test_naive_floor_within_tz_day_return_naive(self):
         """
@@ -674,7 +571,7 @@ class TestFloor(unittest.TestCase):
         """
         t = datetime.datetime(2013, 4, 1)
         # t is in midnight UTC, but it is still in the previous day for EST.
-        ret = fleming.floor(t, day=1, within_tz=pytz.timezone('US/Eastern'), return_naive=True)
+        ret = fleming.floor(t, day=1, within_tz=pytz.timezone('US/Eastern'))
         # The return value should be for the last day of the previous month, and the
         # timezone should still be in UTC
         self.assertEquals(ret, datetime.datetime(2013, 3, 31))
@@ -724,7 +621,7 @@ class TestFloor(unittest.TestCase):
         t = datetime.datetime(2013, 5, 2)
         ret = fleming.floor(t, month=3)
         # The result should be at the beginning of the second quarter
-        self.assertEquals(ret, datetime.datetime(2013, 4, 1, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 4, 1))
 
     def test_quadday_floor(self):
         """
@@ -732,7 +629,7 @@ class TestFloor(unittest.TestCase):
         """
         t = datetime.datetime(2013, 5, 6)
         ret = fleming.floor(t, day=4)
-        self.assertEquals(ret, datetime.datetime(2013, 5, 5, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 5, 5))
 
     def test_halfday_floor(self):
         """
@@ -740,7 +637,7 @@ class TestFloor(unittest.TestCase):
         """
         t = datetime.datetime(2013, 5, 6, 14)
         ret = fleming.floor(t, hour=12)
-        self.assertEquals(ret, datetime.datetime(2013, 5, 6, 12, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 5, 6, 12))
 
     def test_trimonth_triday_floor(self):
         """
@@ -748,13 +645,21 @@ class TestFloor(unittest.TestCase):
         """
         t = datetime.datetime(2013, 1, 8)
         ret = fleming.floor(t, month=3, day=3)
-        self.assertEquals(ret, datetime.datetime(2013, 1, 7, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 1, 7))
 
-    def test_no_floor(self):
+    def test_no_floor_naive(self):
         """
-        Tests that the original time is returned when no floor values are present.
+        Tests that the original naive time is returned when no floor values are present.
         """
         t = datetime.datetime(2013, 4, 6, 7, 8)
+        ret = fleming.floor(t)
+        self.assertEquals(ret, datetime.datetime(2013, 4, 6, 7, 8))
+
+    def test_no_floor_aware(self):
+        """
+        Tests that the original aware time is returned when no floor values are present.
+        """
+        t = datetime.datetime(2013, 4, 6, 7, 8, tzinfo=pytz.utc)
         ret = fleming.floor(t)
         self.assertEquals(ret, datetime.datetime(2013, 4, 6, 7, 8, tzinfo=pytz.utc))
 
@@ -897,7 +802,7 @@ class TestIntervals(unittest.TestCase):
         a count to get the range. Tests when the count is 1
         """
         intervals = fleming.intervals(datetime.datetime(2013, 3, 1), datetime.timedelta(days=1), count=1)
-        self.assertEquals(list(intervals), [datetime.datetime(2013, 3, 1, tzinfo=pytz.utc)])
+        self.assertEquals(list(intervals), [datetime.datetime(2013, 3, 1)])
 
     def test_naive_start_day_td_count(self):
         """
@@ -907,11 +812,11 @@ class TestIntervals(unittest.TestCase):
         intervals = fleming.intervals(datetime.datetime(2013, 3, 1), datetime.timedelta(days=1), count=10)
         self.assertEquals(
             list(intervals), [
-                datetime.datetime(2013, 3, 1, tzinfo=pytz.utc), datetime.datetime(2013, 3, 2, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 3, tzinfo=pytz.utc), datetime.datetime(2013, 3, 4, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 5, tzinfo=pytz.utc), datetime.datetime(2013, 3, 6, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 7, tzinfo=pytz.utc), datetime.datetime(2013, 3, 8, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 9, tzinfo=pytz.utc), datetime.datetime(2013, 3, 10, tzinfo=pytz.utc),
+                datetime.datetime(2013, 3, 1), datetime.datetime(2013, 3, 2),
+                datetime.datetime(2013, 3, 3), datetime.datetime(2013, 3, 4),
+                datetime.datetime(2013, 3, 5), datetime.datetime(2013, 3, 6),
+                datetime.datetime(2013, 3, 7), datetime.datetime(2013, 3, 8),
+                datetime.datetime(2013, 3, 9), datetime.datetime(2013, 3, 10),
             ])
 
     def test_naive_start_day_td_count_return_naive(self):
@@ -919,8 +824,7 @@ class TestIntervals(unittest.TestCase):
         Tests the intervals function with a naive start_dt parameter with a timedelta of a day. Uses
         a count to get the range. Returns objects as naive times.
         """
-        intervals = fleming.intervals(
-            datetime.datetime(2013, 3, 1), datetime.timedelta(days=1), count=10, return_naive=True)
+        intervals = fleming.intervals(datetime.datetime(2013, 3, 1), datetime.timedelta(days=1), count=10)
         self.assertEquals(
             list(intervals), [
                 datetime.datetime(2013, 3, 1), datetime.datetime(2013, 3, 2),
@@ -980,9 +884,9 @@ class TestIntervals(unittest.TestCase):
                 datetime.datetime(2013, 2, 13, 8, tzinfo=est), datetime.datetime(2013, 2, 14, 9, tzinfo=est),
             ])
 
-    def test_naive_within_est_day_td_dst_cross(self):
+    def test_aware_within_est_day_td_dst_cross(self):
         """
-        Tests with a naive start doing the range within another timezone while crossing a dst border.
+        Tests with an aware start doing the range within another timezone while crossing a dst border.
         """
         start_dt = datetime.datetime(2013, 3, 5, tzinfo=pytz.utc)
         intervals = fleming.intervals(
@@ -1007,21 +911,38 @@ class TestIntervals(unittest.TestCase):
             datetime.datetime(2013, 3, 1), datetime.timedelta(days=1), stop_dt=datetime.datetime(2013, 3, 11))
         self.assertEquals(
             list(intervals), [
-                datetime.datetime(2013, 3, 1, tzinfo=pytz.utc), datetime.datetime(2013, 3, 2, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 3, tzinfo=pytz.utc), datetime.datetime(2013, 3, 4, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 5, tzinfo=pytz.utc), datetime.datetime(2013, 3, 6, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 7, tzinfo=pytz.utc), datetime.datetime(2013, 3, 8, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 9, tzinfo=pytz.utc), datetime.datetime(2013, 3, 10, tzinfo=pytz.utc),
+                datetime.datetime(2013, 3, 1), datetime.datetime(2013, 3, 2),
+                datetime.datetime(2013, 3, 3), datetime.datetime(2013, 3, 4),
+                datetime.datetime(2013, 3, 5), datetime.datetime(2013, 3, 6),
+                datetime.datetime(2013, 3, 7), datetime.datetime(2013, 3, 8),
+                datetime.datetime(2013, 3, 9), datetime.datetime(2013, 3, 10),
             ])
 
-    def test_naive_start_day_td_stop_dt_inclusive(self):
+    def test_naive_start_day_td_aware_stop_dt(self):
         """
         Tests the intervals function with a naive start_dt parameter with a timedelta of a day. Uses
-        an inclusive stop_dt to get the range.
+        an aware stop_dt to get the range.
         """
         intervals = fleming.intervals(
-            datetime.datetime(2013, 3, 1), datetime.timedelta(days=1), stop_dt=datetime.datetime(2013, 3, 11),
-            is_stop_dt_inclusive=True)
+            datetime.datetime(2013, 3, 1), datetime.timedelta(days=1),
+            stop_dt=datetime.datetime(2013, 3, 11, tzinfo=pytz.utc))
+        self.assertEquals(
+            list(intervals), [
+                datetime.datetime(2013, 3, 1), datetime.datetime(2013, 3, 2),
+                datetime.datetime(2013, 3, 3), datetime.datetime(2013, 3, 4),
+                datetime.datetime(2013, 3, 5), datetime.datetime(2013, 3, 6),
+                datetime.datetime(2013, 3, 7), datetime.datetime(2013, 3, 8),
+                datetime.datetime(2013, 3, 9), datetime.datetime(2013, 3, 10),
+            ])
+
+    def test_aware_start_day_td_stop_dt_inclusive(self):
+        """
+        Tests the intervals function with an aware start_dt parameter with a timedelta of a day. Uses
+        an inclusive naive stop_dt to get the range.
+        """
+        intervals = fleming.intervals(
+            datetime.datetime(2013, 3, 1, tzinfo=pytz.utc), datetime.timedelta(days=1),
+            stop_dt=datetime.datetime(2013, 3, 11), is_stop_dt_inclusive=True)
         self.assertEquals(
             list(intervals), [
                 datetime.datetime(2013, 3, 1, tzinfo=pytz.utc), datetime.datetime(2013, 3, 2, tzinfo=pytz.utc),
@@ -1043,12 +964,12 @@ class TestIntervals(unittest.TestCase):
             is_stop_dt_inclusive=True)
         self.assertEquals(
             list(intervals), [
-                datetime.datetime(2013, 3, 1, tzinfo=pytz.utc), datetime.datetime(2013, 3, 2, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 3, tzinfo=pytz.utc), datetime.datetime(2013, 3, 4, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 5, tzinfo=pytz.utc), datetime.datetime(2013, 3, 6, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 7, tzinfo=pytz.utc), datetime.datetime(2013, 3, 8, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 9, tzinfo=pytz.utc), datetime.datetime(2013, 3, 10, tzinfo=pytz.utc),
-                datetime.datetime(2013, 3, 11, tzinfo=pytz.utc),
+                datetime.datetime(2013, 3, 1), datetime.datetime(2013, 3, 2),
+                datetime.datetime(2013, 3, 3), datetime.datetime(2013, 3, 4),
+                datetime.datetime(2013, 3, 5), datetime.datetime(2013, 3, 6),
+                datetime.datetime(2013, 3, 7), datetime.datetime(2013, 3, 8),
+                datetime.datetime(2013, 3, 9), datetime.datetime(2013, 3, 10),
+                datetime.datetime(2013, 3, 11),
             ])
 
 
@@ -1058,85 +979,85 @@ class TestCeil(unittest.TestCase):
     """
     def test_naive_ceil_year(self):
         """
-        Tests ceiling a naive datetime to a year and returning an aware datetime.
+        Tests ceiling a naive datetime to a year and returning a naive datetime.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.ceil(t, year=1)
-        self.assertEquals(t, datetime.datetime(2014, 1, 1, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2014, 1, 1))
 
     def test_naive_ceil_month(self):
         """
-        Tests ceiling a naive datetime to a month and returning an aware datetime.
+        Tests ceiling a naive datetime to a month and returning a naive datetime.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.ceil(t, month=1)
-        self.assertEquals(t, datetime.datetime(2013, 4, 1, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 4, 1))
 
     def test_naive_ceil_week_stays_in_month(self):
         """
         Tests ceiling a naive datetime to a week where the month value remains the same.
-        Returns an aware datetime.
+        Returns a naive datetime.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.ceil(t, week=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 11, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 11))
 
     def test_naive_ceil_week_goes_to_next_month(self):
         """
         Tests ceiling a naive datetime to a week where the month value goes forwards.
-        Return value is aware.
+        Return value is naive.
         """
         t = datetime.datetime(2013, 3, 31, 12, 23, 4, 40)
         t = fleming.ceil(t, week=1)
-        self.assertEquals(t, datetime.datetime(2013, 4, 1, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 4, 1))
 
     def test_naive_ceil_day(self):
         """
-        Tests ceiling a naive datetime to a day. Return value is aware.
+        Tests ceiling a naive datetime to a day. Return value is naive.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.ceil(t, day=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 5, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 5))
 
     def test_naive_ceil_day_next_month(self):
         """
-        Tests ceiling a naive datetime to a day when it crosses to the next month. Return value is aware.
+        Tests ceiling a naive datetime to a day when it crosses to the next month. Return value is naive.
         """
         t = datetime.datetime(2013, 2, 28, 12, 23, 4, 40)
         t = fleming.ceil(t, day=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 1, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 1))
 
     def test_naive_ceil_day_return_naive(self):
         """
         Tests ceiling a naive datetime to a day. Return value is naive.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
-        t = fleming.ceil(t, day=1, return_naive=True)
+        t = fleming.ceil(t, day=1)
         self.assertEquals(t, datetime.datetime(2013, 3, 5))
 
     def test_naive_ceil_hour(self):
         """
-        Tests ceiling a naive datetime to an hour. Return value is aware
+        Tests ceiling a naive datetime to an hour. Return value is naive
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.ceil(t, hour=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 4, 13, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 4, 13))
 
     def test_naive_ceil_minute(self):
         """
-        Tests ceiling a naive datetime to a minute. Return value is aware.
+        Tests ceiling a naive datetime to a minute. Return value is naive.
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.ceil(t, minute=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12, 24, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12, 24))
 
     def test_naive_ceil_second(self):
         """
-        Tests ceiling a naive datetime to a minute. Return value is aware
+        Tests ceiling a naive datetime to a minute. Return value is naive
         """
         t = datetime.datetime(2013, 3, 4, 12, 23, 4, 40)
         t = fleming.ceil(t, second=1)
-        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12, 23, 5, tzinfo=pytz.utc))
+        self.assertEquals(t, datetime.datetime(2013, 3, 4, 12, 23, 5))
 
     def test_aware_ceil_year(self):
         """
@@ -1205,16 +1126,16 @@ class TestCeil(unittest.TestCase):
         self.assertEquals(ret.tzinfo.dst(ret), datetime.timedelta(0))
         self.assertEquals(ret, datetime.datetime(2013, 3, 5, tzinfo=t.tzinfo))
 
-    def test_aware_ceil_day_return_naive(self):
+    def test_aware_ceil_day_return_aware(self):
         """
-        Tests ceiling an aware datetime to a day. Return value is naive.
+        Tests ceiling an aware datetime to a day. Return value is aware.
         """
         t = fleming.convert_to_tz(
             datetime.datetime(2013, 3, 4, 12, 23, 4, 40), pytz.timezone('US/Eastern'))
         # Original time zone should not be in DST
         self.assertEquals(t.tzinfo.dst(t), datetime.timedelta(0))
-        ret = fleming.ceil(t, day=1, return_naive=True)
-        self.assertEquals(ret, datetime.datetime(2013, 3, 5))
+        ret = fleming.ceil(t, day=1)
+        self.assertEquals(ret, datetime.datetime(2013, 3, 5, tzinfo=pytz.timezone('US/Eastern')))
 
     def test_aware_ceil_hour(self):
         """
@@ -1306,7 +1227,7 @@ class TestCeil(unittest.TestCase):
         # t is the first in UTC, but it is the next day in Germany.
         ret = fleming.ceil(t, day=1, within_tz=pytz.timezone('Europe/Berlin'))
         # The return value should be for April 3, and the timezone should still be in UTC
-        self.assertEquals(ret, datetime.datetime(2013, 4, 3, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 4, 3))
 
     def test_naive_ceil_within_est_no_diff(self):
         """
@@ -1316,7 +1237,7 @@ class TestCeil(unittest.TestCase):
         t = datetime.datetime(2013, 3, 2)
         ret = fleming.ceil(t, month=1, within_tz=pytz.timezone('US/Eastern'))
         # The return value should be the start of the next month
-        self.assertEquals(ret, datetime.datetime(2013, 4, 1, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 4, 1))
 
     def test_naive_ceil_within_est_diff(self):
         """
@@ -1326,7 +1247,7 @@ class TestCeil(unittest.TestCase):
         t = datetime.datetime(2013, 3, 1)
         ret = fleming.ceil(t, month=1, within_tz=pytz.timezone('US/Eastern'))
         # The return value should be the start of March since it was still Feb in EST
-        self.assertEquals(ret, datetime.datetime(2013, 3, 1, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 3, 1))
 
     def test_cst_ceil_within_est_day(self):
         """
@@ -1359,7 +1280,7 @@ class TestCeil(unittest.TestCase):
         t = datetime.datetime(2013, 11, 2)
         ret = fleming.ceil(t, month=3)
         # The result should be at the beginning of the next quarter
-        self.assertEquals(ret, datetime.datetime(2014, 1, 1, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2014, 1, 1))
 
     def test_quadday_ceil(self):
         """
@@ -1367,7 +1288,7 @@ class TestCeil(unittest.TestCase):
         """
         t = datetime.datetime(2013, 5, 6)
         ret = fleming.ceil(t, day=4)
-        self.assertEquals(ret, datetime.datetime(2013, 5, 9, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 5, 9))
 
     def test_halfday_ceil(self):
         """
@@ -1375,7 +1296,7 @@ class TestCeil(unittest.TestCase):
         """
         t = datetime.datetime(2013, 5, 6, 11)
         ret = fleming.ceil(t, hour=12)
-        self.assertEquals(ret, datetime.datetime(2013, 5, 6, 12, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 5, 6, 12))
 
     def test_trimonth_triday_ceil(self):
         """
@@ -1383,13 +1304,22 @@ class TestCeil(unittest.TestCase):
         """
         t = datetime.datetime(2013, 1, 8)
         ret = fleming.ceil(t, month=3, day=3)
-        self.assertEquals(ret, datetime.datetime(2013, 4, 1, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 4, 1))
 
     def test_no_ceil(self):
         """
-        Tests that the original time is returned when no floor values are present.
+        Tests that the original time is returned when no ceil values are present.
         """
         t = datetime.datetime(2013, 4, 6, 7, 8)
+        ret = fleming.ceil(t)
+        self.assertEquals(ret, datetime.datetime(2013, 4, 6, 7, 8))
+
+    def test_aware_no_ceil(self):
+        """
+        Tests that the original time is returned when no ceil values are present for
+        an aware time.
+        """
+        t = datetime.datetime(2013, 4, 6, 7, 8, tzinfo=pytz.utc)
         ret = fleming.ceil(t)
         self.assertEquals(ret, datetime.datetime(2013, 4, 6, 7, 8, tzinfo=pytz.utc))
 
@@ -1407,7 +1337,7 @@ class TestCeil(unittest.TestCase):
         """
         t = datetime.datetime(2013, 1, 1)
         ret = fleming.ceil(t, year=1)
-        self.assertEquals(ret, datetime.datetime(2013, 1, 1, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 1, 1))
 
     def test_ceil_month_on_boundary(self):
         """
@@ -1415,7 +1345,7 @@ class TestCeil(unittest.TestCase):
         """
         t = datetime.datetime(2013, 5, 1)
         ret = fleming.ceil(t, month=1)
-        self.assertEquals(ret, datetime.datetime(2013, 5, 1, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 5, 1))
 
     def test_ceil_aware_month_on_boundary(self):
         """
@@ -1435,12 +1365,12 @@ class TestCeil(unittest.TestCase):
         """
         t = datetime.datetime(2013, 5, 1, 4)
         ret = fleming.ceil(t, month=1, within_tz=pytz.timezone('US/Eastern'))
-        self.assertEquals(ret, datetime.datetime(2013, 5, 1, tzinfo=pytz.utc))
+        self.assertEquals(ret, datetime.datetime(2013, 5, 1))
 
     def test_ceil_one_microsecond_above_interval(self):
         """
         Tests a ceil when it is only one microsecond above a boundary. It should still be rounded up.
         """
         t = datetime.datetime(2013, 5, 1, 0, 0, 0, 1)
-        ret = fleming.ceil(t, month=1, return_naive=True)
+        ret = fleming.ceil(t, month=1)
         self.assertEquals(ret, datetime.datetime(2013, 6, 1))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='fleming',
-    version='0.2',
+    version='0.3',
     description='Python helpers for manipulating datetime objects relative to time zones',
     long_description='''
         This package contains Fleming, which contains a set of routines for doing datetime
@@ -42,9 +42,9 @@ setup(
     author_email='wesleykendall@gmail.com',
     license='MIT',
     packages=['fleming'],
-    install_requires=['pytz==2013.9', 'python-dateutil==2.2'],
+    install_requires=['pytz>=2013.9', 'python-dateutil>=2.2'],
     include_package_data=True,
     zip_safe=False,
     test_suite='nose.collector',
-    tests_require=['nose==1.3.0'],
+    tests_require=['nose>=1.3.0'],
 )


### PR DESCRIPTION
This release changes the interface of Fleming so that it returns datetime objects as the same awareness as the input datetime object. Previously, the interface always returned aware object even if the input was naive. This is, however, cumbersome for apps that solely want to work in naive time.

This release also doesn't pin dependencies to versions and fixes #8 .
