### PR TITLE
updated tests because of new pytz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# import multiprocessing to avoid this bug (http://bugs.python.org/issue15881#msg170215)
+import multiprocessing
+assert multiprocessing
 from setuptools import setup
 
 


### PR DESCRIPTION
@micahhausler  this updates tests. The time zone definitions for eastern and central changed, so now I use localize() in the tests instead of attaching a tzinfo object.
