### PR TITLE
Avoid use of 'unix_time' identifier in 'unix_time' function

### DIFF
--- a/fleming/fleming.py
+++ b/fleming/fleming.py
@@ -826,5 +826,5 @@ def unix_time(dt, within_tz=None, return_ms=False):
     offset = convert_to_tz(c_dt, within_tz).utcoffset().total_seconds() if within_tz else 0
     # Convert the timezone to UTC for arithmetic and make it naive
     c_dt = convert_to_tz(c_dt, pytz.utc).replace(tzinfo=None)
-    unix_time = (c_dt - epoch).total_seconds() + offset
-    return int(unix_time * 1000 if return_ms else unix_time)
+    unix_timestamp = (c_dt - epoch).total_seconds() + offset
+    return int(unix_timestamp * 1000 if return_ms else unix_timestamp)


### PR DESCRIPTION
This commit renames a variable to avoid defining a variable `unix_time` inside the function `unix_time`. Some Python linters pick up on this with a warning.